### PR TITLE
ConsoleWrapper IE9 binding error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applicationinsights-js-wrappers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "description": "window.onerror, console and functions wrappers for ApplicationInsights-JS",
   "directories": {

--- a/src/ts/wrappers/ConsoleWrapper.ts
+++ b/src/ts/wrappers/ConsoleWrapper.ts
@@ -88,9 +88,12 @@ class ConsoleWrapper implements IWrapper {
 				level--;
 			}
 
-			this._console[level].bind(console)(message);
+			if ('bind' in this._console[level]) {
+				this._console[level].bind(console)(message);
+			} else {
+				Function.prototype.bind(this._console[level], console)(message);
+			}
 		}
-
 	}
 
 	private handleLog(message?: any, ...optionalParams: any[]): void {


### PR DESCRIPTION
IE9 console methods do no support binding